### PR TITLE
Do not mark bazel-build-test action as failed on ReserveCacheError.

### DIFF
--- a/bazel-build-test/index.js
+++ b/bazel-build-test/index.js
@@ -58,7 +58,16 @@ async function run() {
   if (!validTestExitCodes.includes(testExitCode)) {
     throw new Error('Testing failed');
   }
-  await cache.saveCache(cachePaths, cacheKey);
+
+  try {
+    await cache.saveCache(cachePaths, cacheKey);
+  } catch (err) {
+    if (err.name === cache.ReserveCacheError.name) {
+      core.warning(err);
+    } else {
+      throw err;
+    }
+  }
 }
 
 async function main() {


### PR DESCRIPTION
This is to work around https://github.com/actions/toolkit/issues/658