### PR TITLE
Add cache-version input to bazel-build-test action.

### DIFF
--- a/bazel-build-test/action.yml
+++ b/bazel-build-test/action.yml
@@ -19,6 +19,10 @@ inputs:
     description: Path of Bazel workspace
     required: true
     default: .
+  cache-version:
+    description: Version of the GitHub Actions cache key.
+    required: false
+    default: 0
   build-options:
     # TODO(actions/toolkit#184): Use list type rather than newline-delimited
     # string once it's available.

--- a/bazel-build-test/index.js
+++ b/bazel-build-test/index.js
@@ -32,7 +32,8 @@ async function run() {
   const treeHash = await execBash(['git rev-parse HEAD:']);
   const outputBase = await execBash(['bazelisk info output_base'])
 
-  const cacheKey = `bazel-${execRootHash}-${treeHash}`;
+  const cacheVersion = core.getInput('cache-version');
+  const cacheKey = `bazel-${cacheVersion}-${execRootHash}-${treeHash}`;
   const cachePaths = [outputBase];
   if (getInputBool('restore-cache')) {
     const restoreKeys = [`bazel-${execRootHash}-`];


### PR DESCRIPTION
This allows for manually invalidating prior cache results when there are incompatible changes that Bazel doesn't handle. For example, changing the C++ compiler version.

See https://github.com/bazelbuild/bazel/issues/4558