### PR TITLE
Warn rather than fail on ReserveCacheError in setup-linters action.

### DIFF
--- a/setup-linters/index.js
+++ b/setup-linters/index.js
@@ -44,9 +44,17 @@ function buildTool(name, version, ext = '') {
     cacheKey: [basename, version].join('-'),
 
     async save() {
-      const cacheId = await cache.saveCache([this.path], this.cacheKey);
-      core.info(`Saved ${this.cacheKey} to cache`);
-      return cacheId;
+      try {
+        const cacheId = await cache.saveCache([this.path], this.cacheKey);
+        core.info(`Saved ${this.cacheKey} to cache`);
+        return cacheId;
+      } catch (err) {
+        if (err.name === cache.ReserveCacheError.name) {
+          core.warning(err);
+        } else {
+          throw err;
+        }
+      }
     },
 
     async restore() {


### PR DESCRIPTION
This is similar to #3 for the bazel-build-test action.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/world-federation-of-advertisers/actions/12)
<!-- Reviewable:end -->
