### PR TITLE
Add excluded-cache-file-patterns option to bazel-build-test.

### DIFF
--- a/.github/workflows/test-bazel-build-test.yml
+++ b/.github/workflows/test-bazel-build-test.yml
@@ -55,6 +55,9 @@ jobs:
       uses: ./bazel-build-test
       with:
         workspace-path: .
+        cache-save-events: |
+          pull_request
+          push
   failing-test-target:
     name: Run with failing test target
     runs-on: ubuntu-20.04

--- a/bazel-build-test/action.yml
+++ b/bazel-build-test/action.yml
@@ -31,6 +31,16 @@ inputs:
       Newline-delimited.
     required: false
     default: push
+  excluded-cache-file-patterns:
+    # TODO(actions/toolkit#184): Use list type rather than newline-delimited
+    # string once it's available.
+    description: >-
+      File name patterns to exclude from the cache. Newline-delimited.
+      
+      These are passed to the `-iname` option of GNU find. The exclusion is
+      implemented by deleting the files prior to saving the cache.
+    required: false
+    default: '*.tar'
   build-options:
     # TODO(actions/toolkit#184): Use list type rather than newline-delimited
     # string once it's available.

--- a/bazel-build-test/package.json
+++ b/bazel-build-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bazel-build-test",
-  "version": "1.8.0",
+  "version": "1.9.0",
   "description": "Javascript GitHub Action for building and testing with Bazel",
   "main": "index.js",
   "scripts": {

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -4,7 +4,7 @@
   "requires": true,
   "packages": {
     "bazel-build-test": {
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ]
     },
     "bazel-build-test": {
-      "version": "1.8.0",
+      "version": "1.9.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/artifact": "^1.1.0",


### PR DESCRIPTION
This excludes files from the build cache. By default it excludes tar archives.

The idea is to avoid filling the Actions cache with large files that can be cheaply regenerated.