### PR TITLE
Fix build options not being passed to `info bazel-bin` command.

### DIFF
--- a/bazel-build-test/index.js
+++ b/bazel-build-test/index.js
@@ -90,9 +90,11 @@ async function deleteExcludedFiles(excludedFileNamePatterns) {
   }
   findArgs.push('-delete');
 
-  const binDir = (await exec.getExecOutput('bazelisk', ['info', 'bazel-bin'], {
+  const bazelArgs = ['info'].concat(common.buildOptions).concat('bazel-bin');
+  const binDir = (await exec.getExecOutput('bazelisk', bazelArgs, {
                    cwd: workspacePath
                  })).stdout.trimEnd();
+
   await exec.exec('find', findArgs, {cwd: binDir});
 }
 

--- a/bazel-build-test/package.json
+++ b/bazel-build-test/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bazel-build-test",
-  "version": "1.9.0",
+  "version": "1.9.1",
   "description": "Javascript GitHub Action for building and testing with Bazel",
   "main": "index.js",
   "scripts": {

--- a/node_modules/.package-lock.json
+++ b/node_modules/.package-lock.json
@@ -4,7 +4,7 @@
   "requires": true,
   "packages": {
     "bazel-build-test": {
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/artifact": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       ]
     },
     "bazel-build-test": {
-      "version": "1.9.0",
+      "version": "1.9.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@actions/artifact": "^1.1.0",


### PR DESCRIPTION
Some build options, such as `--compilation_mode=opt`, can affect the path.

Fixes a bug introduced in #31.