### PR TITLE
Fix setup-linters step in lint action.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
         shell: bash
     steps:
     - name: Check out revision
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -32,13 +32,18 @@ inputs:
 runs:
   using: composite
   steps:
+    # Check out repo so we can use local actions.
+    - uses: actions/checkout@v3
+      with:
+        path: .github/actions
+
     - uses: actions/setup-java@v3
       with:
         distribution: zulu
         java-version: '11'
 
     - name: Set up linters
-      uses: ./setup-linters
+      uses: ./.github/actions/setup-linters
 
     - name: Install cpplint
       shell: bash


### PR DESCRIPTION
The composite action was not usable from other repositories.