### PR TITLE
adding linting for typescript

### DIFF
--- a/lint/action.yml
+++ b/lint/action.yml
@@ -50,6 +50,10 @@ runs:
       shell: bash
       run: pip3 install --user cpplint
 
+    - name: Install gts
+      shell: bash
+      run: npm install --save-dev gts eslint eslint-config-react-app prettier
+
     - name: Lint
       shell: bash
       env:

--- a/lint/lint.sh
+++ b/lint/lint.sh
@@ -22,6 +22,7 @@ readonly CPP_OR_PROTO_PATTERN='\.(cc|h|proto)$'
 readonly CPP_PATTERN='\.(cc|h)$'
 readonly JAVA_PATTERN='\.java$'
 readonly CUE_PATTERN='\.cue$'
+readonly TS_PATTERN='\.(ts|tsx)$'
 
 # Reads exclude pathspecs from the .lintignore file into the specified array.
 read_exclude_pathspecs() {
@@ -131,6 +132,10 @@ google_java_format_cmd() {
   google-java-format --dry-run "$@"
 }
 
+typescript_fmt_cmd() {
+  npx gts lint --dry-run "$@"
+}
+
 # Runs the linter command on changed files with the specified regex pattern.
 #
 # Scope vars:
@@ -173,6 +178,7 @@ main() {
   run_linter cpplint_cmd "${CPP_PATTERN}" || has_errors=1
   run_linter google_java_format_cmd "${JAVA_PATTERN}" || has_errors=1
   run_linter cue_fmt_cmd "${CUE_PATTERN}" || has_errors=1
+  run_linter typescript_fmt_cmd "${TS_PATTERN}" || has_errors=1
 
   ! ((has_errors))
 }


### PR DESCRIPTION
Adding GTS as a linter for typescript.
GTS wraps eslint, eslint for react, and prettier and comes with default (yet overridable) configurations.
This is to support the React/Typescript UI work in cross-media-measurement.